### PR TITLE
fix(dev): Torna o script predev multiplataforma

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "link": "npm unlink constatic && npm link",
     "build": "tsup",
     "test": "npm run build && npm run link",
-    "predev": "rm -rf playground && mkdir playground",
+    "predev": "tsx scripts/predev.ts",
     "dev": "npm run build && cd playground && constatic",
     "tsx": "tsx",
     "check": "tsc --noEmit"

--- a/scripts/predev.ts
+++ b/scripts/predev.ts
@@ -1,0 +1,6 @@
+import fs from 'fs-extra';
+
+// The `dev` script runs `constatic` inside the `playground` directory.
+// We need to clean it up before running the tests.
+fs.removeSync('./playground');
+fs.ensureDirSync('./playground');


### PR DESCRIPTION
Este pull request corrige um problema que impedia o comando `npm run dev` de funcionar em sistemas Windows.

O script `predev` utilizava o comando `rm -rf`, que é específico para ambientes Unix e não está disponível por padrão no prompt de comando do Windows (cmd.exe).

Esta alteração substitui o comando de shell por um script Node.js multiplataforma, utilizando o pacote `fs-extra` (que já é uma dependência do projeto). Isso garante que o ambiente de desenvolvimento possa ser configurado corretamente em qualquer sistema operacional.
