### PR TITLE
feat: add tema padrão em RootProvider

### DIFF
--- a/apps/docs/src/app/[lang]/layout.tsx
+++ b/apps/docs/src/app/[lang]/layout.tsx
@@ -15,6 +15,7 @@ export default async function Layout({ children, params }: LayoutProps<"/[lang]"
       <body className="flex flex-col min-h-screen">
         <RootProvider
           i18n={i18nProvider(lang)}
+          theme={{ defaultTheme: 'dark' }}
         >
           {children}
         </RootProvider>


### PR DESCRIPTION
O visual do site foi, aparentemente, planejado para o modo escuro. Entretanto ao utilizar o SO com tema claro está sendo bem ruim de visualizar. A alteração tem a finalidade de definir o tema `dark` como o padrão para que mesmo que o sistema esteja no modo claro ainda seja utilizado o `dark`.